### PR TITLE
feat: metrics instrumentation coverage analyzer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM thinxcloud/base:alpine
 
 LABEL maintainer="Matej Sychra <suculent@me.com>"
-LABEL name="THiNX API" version="1.9.2739"
+LABEL name="THiNX API" version="1.9.2866"
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,7 +1,7 @@
 FROM thinxcloud/base:alpine
 
 LABEL maintainer="Matej Sychra <suculent@me.com>"
-LABEL name="THiNX API" version="1.9.2739"
+LABEL name="THiNX API" version="1.9.2866"
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "jasmine": "nyc jasmine",
     "test": "mkdir -p coverage; jasmine; [ -n \"$COVERALLS_REPO_TOKEN\" ] && nyc report --reporter=text-lcov > coverage/lcov.info && coveralls < coverage/lcov.info || true",
     "dev": "source ./.env && echo $ENVIRONMENT && nyc jasmine; nyc report --reporter=text-lcov > coverage/lcov.info; coveralls < coverage/lcov.info",
+    "metrics-coverage": "node scripts/metrics-coverage.js",
     "lint": "eslint --config ./.eslintrc --ignore-path ./.eslintignore ./",
     "coverage": "npm run mocha",
     "mocha": "mocha spec/jasmine --delay=3000 --exit --timeout=5000; nyc report --reporter=text-lcov > lcov.info && cat lcov.info | node node_modules/coveralls/bin/coveralls.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinx",
-  "version": "1.9.2739",
+  "version": "1.9.2866",
   "description": "THiNX IoT Device Management API",
   "bugs": {
     "url": "https://github.com/suculent/thinx-device-api/issues"

--- a/scripts/metrics-coverage.js
+++ b/scripts/metrics-coverage.js
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+/**
+ * Metrics Coverage Analyzer
+ * Scans lib/ files to report InfluxConnector.statsLog instrumentation coverage.
+ * Usage: node scripts/metrics-coverage.js [--json] [--verbose]
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const LIB_DIR = path.join(ROOT, 'lib');
+
+// Files that are infrastructure/utilities and not expected to emit metrics
+const EXCLUDED_FILES = new Set([
+    'influx.js',       // the metrics connector itself
+    'globals.js',      // global config
+    'util.js',         // pure utilities
+    'sanitka.js',      // input sanitization
+    'validator.js',    // data validation
+    'json2h.js',       // format converter
+    'database.js',     // db connection
+    'router.js',       // main router bootstrap (no business logic)
+    'acl.js',          // access control list data
+    'platform.js',     // platform definitions
+    'plugins.js',      // plugin loader
+    'coap.js',         // CoAP protocol handler (low-level)
+]);
+
+// Patterns indicating metrics instrumentation
+const INSTRUMENTATION_PATTERNS = [
+    /InfluxConnector\.statsLog\s*\(/,
+    /statsLog\s*\(/,
+    /influx\.statsLog\s*\(/,
+];
+
+// Patterns for metrics events to extract
+const EVENT_PATTERN = /statsLog\s*\([^,]+,\s*["']([A-Z_]+)["']/g;
+
+/**
+ * Collect all .js files recursively under a directory.
+ * Skips plugin subdirectories which are platform adapters.
+ */
+function collectFiles(dir, files = []) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            // Skip plugins dir - those are build-system adapters, not API logic
+            if (entry.name !== 'plugins') {
+                collectFiles(full, files);
+            }
+        } else if (entry.name.endsWith('.js')) {
+            files.push(full);
+        }
+    }
+    return files;
+}
+
+/**
+ * Analyze a single file for metrics instrumentation.
+ */
+function analyzeFile(filePath) {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const relPath = path.relative(ROOT, filePath);
+    const basename = path.basename(filePath);
+
+    const isExcluded = EXCLUDED_FILES.has(basename);
+    const hasInstrumentation = !isExcluded && INSTRUMENTATION_PATTERNS.some(p => p.test(content));
+
+    const events = [];
+    if (hasInstrumentation) {
+        let match;
+        const re = new RegExp(EVENT_PATTERN.source, 'g');
+        while ((match = re.exec(content)) !== null) {
+            if (!events.includes(match[1])) {
+                events.push(match[1]);
+            }
+        }
+    }
+
+    // Classify file type
+    let type;
+    if (basename.startsWith('router.')) {
+        type = 'router';
+    } else if (relPath.startsWith('lib/thinx/')) {
+        type = 'service';
+    } else {
+        type = 'other';
+    }
+
+    return { relPath, basename, type, isExcluded, hasInstrumentation, events };
+}
+
+/**
+ * Group results and compute coverage metrics.
+ */
+function buildReport(results) {
+    const instrumented = results.filter(r => !r.isExcluded && r.hasInstrumentation);
+    const uninstrumented = results.filter(r => !r.isExcluded && !r.hasInstrumentation);
+    const excluded = results.filter(r => r.isExcluded);
+    const total = instrumented.length + uninstrumented.length;
+    const pct = total > 0 ? Math.round((instrumented.length / total) * 100) : 0;
+
+    // Collect all unique event types across instrumented files
+    const allEvents = [...new Set(instrumented.flatMap(r => r.events))].sort();
+
+    return {
+        summary: {
+            total_files: results.length,
+            excluded_files: excluded.length,
+            eligible_files: total,
+            instrumented_files: instrumented.length,
+            uninstrumented_files: uninstrumented.length,
+            coverage_pct: pct,
+            tracked_events: allEvents,
+        },
+        instrumented: instrumented.map(r => ({ file: r.relPath, type: r.type, events: r.events })),
+        uninstrumented: uninstrumented.map(r => ({ file: r.relPath, type: r.type })),
+        excluded: excluded.map(r => ({ file: r.relPath, type: r.type })),
+    };
+}
+
+function printReport(report, verbose) {
+    const s = report.summary;
+    const bar = (n, total) => {
+        const filled = Math.round((n / Math.max(total, 1)) * 20);
+        return '[' + '█'.repeat(filled) + '░'.repeat(20 - filled) + ']';
+    };
+
+    console.log('\n=== Metrics Instrumentation Coverage ===\n');
+    console.log(`  Eligible files : ${s.eligible_files}`);
+    console.log(`  Instrumented   : ${s.instrumented_files}`);
+    console.log(`  Missing        : ${s.uninstrumented_files}`);
+    console.log(`  Excluded       : ${s.excluded_files} (infrastructure/utilities)`);
+    console.log(`\n  Coverage       : ${bar(s.instrumented_files, s.eligible_files)} ${s.coverage_pct}%\n`);
+
+    console.log(`  Tracked events (${s.tracked_events.length}): ${s.tracked_events.join(', ')}\n`);
+
+    console.log('--- Instrumented Files ---');
+    for (const f of report.instrumented) {
+        const evtStr = f.events.length ? `  [${f.events.join(', ')}]` : '';
+        console.log(`  ✓  ${f.file}${evtStr}`);
+    }
+
+    console.log('\n--- Files Missing Instrumentation ---');
+    const byType = {};
+    for (const f of report.uninstrumented) {
+        (byType[f.type] = byType[f.type] || []).push(f);
+    }
+    for (const type of Object.keys(byType).sort()) {
+        console.log(`\n  [${type}]`);
+        for (const f of byType[type]) {
+            console.log(`  ✗  ${f.file}`);
+        }
+    }
+
+    if (verbose) {
+        console.log('\n--- Excluded (infrastructure/utilities) ---');
+        for (const f of report.excluded) {
+            console.log(`  –  ${f.file}`);
+        }
+    }
+
+    console.log('');
+}
+
+function main() {
+    const args = process.argv.slice(2);
+    const jsonMode = args.includes('--json');
+    const verbose = args.includes('--verbose') || args.includes('-v');
+
+    const files = collectFiles(LIB_DIR);
+    const results = files.map(analyzeFile);
+    const report = buildReport(results);
+
+    if (jsonMode) {
+        console.log(JSON.stringify(report, null, 2));
+    } else {
+        printReport(report, verbose);
+    }
+
+    // Exit with non-zero if coverage is below threshold (default 0 = no gate)
+    const threshold = parseInt(args.find(a => a.startsWith('--threshold='))?.split('=')[1] ?? '0', 10);
+    if (report.summary.coverage_pct < threshold) {
+        if (!jsonMode) {
+            console.error(`\nFAIL: coverage ${report.summary.coverage_pct}% is below threshold ${threshold}%`);
+        }
+        process.exit(1);
+    }
+}
+
+main();

--- a/spec/jasmine/MetricsCoverageSpec.js
+++ b/spec/jasmine/MetricsCoverageSpec.js
@@ -1,0 +1,110 @@
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const SCRIPT = path.resolve(__dirname, '../../scripts/metrics-coverage.js');
+const ROOT = path.resolve(__dirname, '../..');
+
+describe("Metrics Coverage Analyzer", function () {
+
+    let report;
+
+    beforeAll(function () {
+        const out = execFileSync(process.execPath, [SCRIPT, '--json'], {
+            cwd: ROOT,
+            encoding: 'utf8'
+        });
+        report = JSON.parse(out);
+    });
+
+    it("should return a valid report structure", function () {
+        expect(report).toBeDefined();
+        expect(report.summary).toBeDefined();
+        expect(report.instrumented).toBeDefined();
+        expect(report.uninstrumented).toBeDefined();
+        expect(report.excluded).toBeDefined();
+    });
+
+    it("should report at least one instrumented file", function () {
+        expect(report.summary.instrumented_files).toBeGreaterThan(0);
+    });
+
+    it("should identify the known-instrumented files", function () {
+        const files = report.instrumented.map(f => f.file);
+        expect(files.some(f => f.includes('router.auth.js'))).toBeTrue();
+        expect(files.some(f => f.includes('apikey.js'))).toBeTrue();
+        expect(files.some(f => f.includes('builder.js'))).toBeTrue();
+        expect(files.some(f => f.includes('device.js'))).toBeTrue();
+        expect(files.some(f => f.includes('devices.js'))).toBeTrue();
+        expect(files.some(f => f.includes('notifier.js'))).toBeTrue();
+    });
+
+    it("should track the standard event types", function () {
+        const events = report.summary.tracked_events;
+        expect(events).toContain('APIKEY_INVALID');
+        expect(events).toContain('LOGIN_INVALID');
+        expect(events).toContain('DEVICE_NEW');
+        expect(events).toContain('DEVICE_CHECKIN');
+        expect(events).toContain('DEVICE_REVOCATION');
+        expect(events).toContain('BUILD_STARTED');
+        expect(events).toContain('BUILD_SUCCESS');
+        expect(events).toContain('BUILD_FAILED');
+    });
+
+    it("should report coverage percentage between 0 and 100", function () {
+        expect(report.summary.coverage_pct).toBeGreaterThanOrEqual(0);
+        expect(report.summary.coverage_pct).toBeLessThanOrEqual(100);
+    });
+
+    it("should exclude infrastructure/utility files", function () {
+        const excluded = report.excluded.map(f => path.basename(f.file));
+        expect(excluded).toContain('influx.js');
+        expect(excluded).toContain('globals.js');
+        expect(excluded).toContain('util.js');
+    });
+
+    it("should not list influx.js as instrumented or uninstrumented", function () {
+        const instrumented = report.instrumented.map(f => f.file);
+        const uninstrumented = report.uninstrumented.map(f => f.file);
+        expect(instrumented.some(f => f.includes('influx.js'))).toBeFalse();
+        expect(uninstrumented.some(f => f.includes('influx.js'))).toBeFalse();
+    });
+
+    it("should classify router files correctly", function () {
+        const routers = report.uninstrumented.filter(f => f.type === 'router');
+        expect(routers.length).toBeGreaterThan(0);
+        routers.forEach(r => {
+            expect(path.basename(r.file)).toMatch(/^router\./);
+        });
+    });
+
+    it("should classify service files correctly", function () {
+        const services = report.uninstrumented.filter(f => f.type === 'service');
+        expect(services.length).toBeGreaterThan(0);
+        services.forEach(s => {
+            expect(s.file).toContain('lib/thinx/');
+        });
+    });
+
+    it("should exit 0 with no threshold set", function () {
+        expect(() => {
+            execFileSync(process.execPath, [SCRIPT, '--json'], {
+                cwd: ROOT,
+                encoding: 'utf8'
+            });
+        }).not.toThrow();
+    });
+
+    it("should exit non-zero when threshold exceeds coverage", function () {
+        let threw = false;
+        try {
+            execFileSync(process.execPath, [SCRIPT, '--json', '--threshold=100'], {
+                cwd: ROOT,
+                encoding: 'utf8'
+            });
+        } catch (e) {
+            threw = true;
+            expect(e.status).toBeGreaterThan(0);
+        }
+        expect(threw).toBeTrue();
+    });
+});


### PR DESCRIPTION
## Summary
- Adds `scripts/metrics-coverage.js` — a static analyzer that scans `lib/` files and reports which router and service modules have `InfluxConnector.statsLog` instrumentation
- Reports coverage percentage, tracked event types, and lists uninstrumented files grouped by type (router/service)
- Adds `npm run metrics-coverage` script to package.json
- Adds `spec/jasmine/MetricsCoverageSpec.js` for automated verification

## Current Coverage

Out of 42 eligible files (excluding infrastructure/utilities), **6 are instrumented (14%)**:
- `lib/router.auth.js` → LOGIN_INVALID
- `lib/thinx/apikey.js` → APIKEY_INVALID
- `lib/thinx/builder.js` → BUILD_FAILED, BUILD_STARTED
- `lib/thinx/device.js` → DEVICE_CHECKIN, DEVICE_NEW
- `lib/thinx/devices.js` → DEVICE_REVOCATION
- `lib/thinx/notifier.js` → BUILD_SUCCESS

## Usage

```
node scripts/metrics-coverage.js           # human-readable report
node scripts/metrics-coverage.js --json    # JSON output
node scripts/metrics-coverage.js --threshold=25  # fail if coverage < 25%
npm run metrics-coverage
```

## Test plan
- [x] Script runs and produces valid JSON output
- [x] All 6 known-instrumented files are identified correctly
- [x] All 8 standard event types are detected
- [x] Infrastructure files (influx.js, globals.js, etc.) are excluded
- [x] Threshold flag triggers non-zero exit when coverage is below threshold
- [x] MetricsCoverageSpec.js covers all above assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)