### PR TITLE
docs: groom task definitions

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -19,6 +19,36 @@ The codebase contains **792 `console.log` calls** across **49 files** in `lib/`.
 - Structured JSON output for log aggregation
 - Correlation IDs per request for tracing
 
+**Scope boundaries:**
+- Cover application code under `lib/` first; generated assets and vendored frontend
+  libraries are out of scope.
+- Preserve current log messages where they are useful, but redact credentials,
+  tokens, session IDs, API keys, and request bodies that may contain secrets.
+- Do not change request handling, build behavior, or deployment configuration
+  beyond logger wiring.
+
+**Acceptance criteria:**
+- A shared logger module is available to backend modules with documented
+  environment-based log level configuration.
+- Direct `console.log`, `console.warn`, and `console.error` calls are removed
+  from the scoped backend modules or explicitly justified in code review.
+- Request-scoped logs include a stable correlation identifier when one is
+  available.
+- Production defaults avoid debug-level output and secret-bearing fields.
+
+**Validation steps:**
+- Run `npm test`.
+- Run `npm run lint` after the logger migration and ESLint configuration agree
+  on intentional logger usage.
+- Smoke-test `GET /api/v2/status` and one authenticated route, then confirm
+  logs are structured JSON and do not expose credentials.
+
+**Risks and implementation notes:**
+- Logging changes can accidentally remove operational signals; migrate in small
+  module batches and compare before/after log volume.
+- Treat any newly discovered secret logging as a security bug, not as a logging
+  cleanup detail.
+
 ---
 
 ### 2. ~~Fix Potential Command Injection in `builder.js`~~ ✅ Implemented
@@ -60,6 +90,32 @@ Use `util.promisify` for Node core callbacks and wrap CouchDB (`nano`) calls wit
 - Eliminates deeply nested "callback pyramids"
 - Easier unit testing
 
+**Scope boundaries:**
+- Start with one module per PR and keep exported CommonJS APIs compatible.
+- Do not combine async migration with unrelated validation, schema, or route
+  behavior changes.
+- Keep callback adapters where callers still depend on callback signatures.
+
+**Acceptance criteria:**
+- The selected module uses `async`/`await` internally for CouchDB, Redis, file
+  system, and crypto operations where practical.
+- Existing callers continue to receive the same success and error shapes.
+- Tests cover at least one successful path and one failure path through each
+  converted async boundary.
+- No unhandled promise rejections are introduced during the module test run.
+
+**Validation steps:**
+- Run the focused Jasmine specs for the converted module.
+- Run `npm test` before merging the first module conversion in each batch.
+- Exercise the corresponding API route or build path manually when the module
+  is used by request handling.
+
+**Risks and implementation notes:**
+- `nano` and Redis callback semantics may not map one-to-one to promises; wrap
+  them behind local helpers before changing business logic.
+- Avoid converting broad dependency chains in one PR unless the tests already
+  isolate the full path.
+
 ---
 
 ### 5. Strengthen Error Handling
@@ -72,22 +128,77 @@ There are only **58 `try` blocks** and **81 `catch` blocks** across the entire `
 - Add `process.on('unhandledRejection', ...)` and `process.on('uncaughtException', ...)` handlers in `thinx.js` entry point — wire them to the existing Rollbar integration in `lib/thinx/globals.js`
 - Wrap all external I/O calls in `try/catch` blocks systematically
 
+**Scope boundaries:**
+- Define shared error response behavior first, then migrate high-risk routes and
+  background workers incrementally.
+- Do not mask authentication or authorization failures behind generic `500`
+  responses.
+- Keep public response bodies free of stack traces and internal service names.
+
+**Acceptance criteria:**
+- Express has a final error middleware that returns a consistent JSON envelope
+  with appropriate HTTP status codes.
+- Process-level rejection and exception handlers report through the existing
+  Rollbar integration and log enough context to diagnose the failure.
+- External I/O failures in the first migrated route group are handled with
+  explicit user-facing status codes and internal diagnostic logs.
+- Tests assert the JSON shape for at least one validation error, one auth error,
+  and one unexpected server error.
+
+**Validation steps:**
+- Run `npm test`.
+- Add or run focused route tests that force CouchDB or Redis failure paths.
+- Manually trigger a rejected promise in a non-production environment and verify
+  Rollbar/log reporting without exposing secrets.
+
+**Risks and implementation notes:**
+- Global handlers can hide crash loops if they only log and continue; define
+  when the process should exit after an unrecoverable exception.
+- Error response normalization may affect clients that depend on legacy body
+  shapes, so document any intentional response contract changes.
+
 ---
 
 ### 6. Resolve Hardcoded RSA Key Passphrase
 **Effort:** Small (half day)
 
-`lib/thinx/rsakey.js:130` contains a hardcoded passphrase `'thinx'` for RSA key encryption with a TODO comment acknowledging the issue:
+`lib/thinx/rsakey.js:130` contains a hardcoded passphrase `'thinx'` for RSA key encryption and an inline note that key encryption should move to secure storage:
 ```js
-passphrase: 'thinx' // TODO: once we'll have Secure Storage (e.g. Vault), keys can be encrypted...
+passphrase: 'thinx'
 ```
 
 **Recommendation:**
 - Read the passphrase from an environment variable (e.g., `process.env.RSA_KEY_PASSPHRASE`) with a documented fallback strategy
-- Consider integrating with HashiCorp Vault or AWS Secrets Manager for secret management (already referenced in the TODO)
+- Consider integrating with HashiCorp Vault or AWS Secrets Manager for secret management
 - Rotate any keys encrypted with the current hardcoded passphrase after the fix
 
 **Risks if unaddressed:** Anyone with read access to the source code can decrypt private RSA keys stored on disk.
+
+**Scope boundaries:**
+- Replace the source literal with configuration loading and clear startup
+  validation.
+- Do not silently re-encrypt existing keys in the same change unless a migration
+  plan and rollback path are documented.
+- Keep local test fixtures deterministic without using production secrets.
+
+**Acceptance criteria:**
+- Runtime RSA key encryption reads the passphrase from configuration or a secret
+  provider.
+- Missing production configuration fails fast with a clear startup error.
+- Test and development environments use an explicit documented fixture value.
+- A key rotation or re-encryption plan exists for keys protected by the old
+  literal passphrase.
+
+**Validation steps:**
+- Run the RSA key Jasmine specs.
+- Run `npm test`.
+- Start the API once with the passphrase configured and once without it in a
+  production-like environment to verify startup behavior.
+
+**Risks and implementation notes:**
+- Changing the passphrase without migrating stored keys can make existing
+  private keys unreadable.
+- Avoid logging the configured secret or derived key material during validation.
 
 ---
 
@@ -129,6 +240,29 @@ The current `.eslintrc.js` disables nearly all rules, including critical ones:
 3. Enable `no-console` after structured logger is in place (improvement #1)
 4. Consider migrating to ESLint flat config format (required for ESLint 10+)
 
+**Scope boundaries:**
+- Enable one stricter rule per PR unless the violations are purely mechanical.
+- Exclude generated, vendored, and legacy third-party frontend assets from the
+  first backend linting pass.
+- Keep formatting-only changes separate from behavior changes when possible.
+
+**Acceptance criteria:**
+- The selected rule is enabled in the active ESLint configuration.
+- Existing violations for that rule are fixed or documented with narrow
+  `eslint-disable` comments.
+- CI runs the lint script or a documented equivalent before merge.
+
+**Validation steps:**
+- Run `npm run lint`.
+- Run `npm test` when the lint fixes touch executable code.
+- Review the diff for accidental formatting churn in unrelated files.
+
+**Risks and implementation notes:**
+- `no-undef` can surface implicit globals used by legacy browser code; scope the
+  first pass to backend files or define browser globals explicitly.
+- Enable `no-console` only after the structured logger task provides a supported
+  replacement.
+
 ---
 
 ### 9. ~~Add OpenAPI/Swagger Specification~~ ✅ Implemented
@@ -149,6 +283,32 @@ The current `.eslintrc.js` disables nearly all rules, including critical ones:
 - Consider `express-slow-down` for a softer degradation approach on login attempts
 - Ensure rate limiting is tested (currently skipped in the test environment)
 
+**Scope boundaries:**
+- Cover login, registration, password reset, and token exchange endpoints first.
+- Keep non-authenticated status and health endpoints on the existing global
+  limiter.
+- Do not introduce shared state that breaks horizontal scaling across API
+  replicas.
+
+**Acceptance criteria:**
+- Sensitive auth routes have a stricter limiter than the global API limiter.
+- Limit keys account for client IP and any available account identifier without
+  logging credentials.
+- Exceeded limits return a consistent status and body that clients can handle.
+- Tests cover allowed requests, blocked requests, and limiter reset behavior.
+
+**Validation steps:**
+- Run the focused route tests for auth and password flows.
+- Run `npm test`.
+- In a local or staging environment, exceed the configured threshold and verify
+  response status, headers, and logs.
+
+**Risks and implementation notes:**
+- Incorrect proxy trust settings can collapse all users into one IP bucket;
+  confirm Traefik or upstream proxy headers before relying on IP keys.
+- Avoid account enumeration through different rate-limit responses for known
+  and unknown users.
+
 ---
 
 ### 11. Add JSDoc Type Annotations to Public APIs
@@ -165,6 +325,30 @@ The codebase has **fewer than 60 JSDoc annotations** across all `lib/thinx/` fil
 
 **Benefits:** Better IDE support, enables TypeScript migration path, documents API contracts.
 
+**Scope boundaries:**
+- Annotate exported functions and shared data structures before private helpers.
+- Keep annotations descriptive; do not change runtime code solely to satisfy a
+  documentation shape.
+- Prefer local typedefs for CouchDB documents, owner records, devices, and build
+  requests that appear across modules.
+
+**Acceptance criteria:**
+- The selected module has `@param`, `@returns`, and relevant `@typedef`
+  coverage for every exported function.
+- Optional and nullable values are documented explicitly.
+- Error callback or rejected promise shapes are documented for public methods.
+- IDE type hints improve without requiring TypeScript compilation.
+
+**Validation steps:**
+- Run `npm test` if executable comments or examples are changed.
+- Generate or inspect editor IntelliSense for one annotated module.
+- Review the annotations against existing specs and API docs for consistency.
+
+**Risks and implementation notes:**
+- Incorrect annotations are worse than missing annotations; derive types from
+  tests and observed document shapes rather than guesses.
+- This task should not be used to rename public fields or normalize schemas.
+
 ---
 
 ## Low Priority
@@ -178,6 +362,32 @@ The codebase has **fewer than 60 JSDoc annotations** across all `lib/thinx/` fil
 - Move sensitive test fixture values to environment variables with `.env.test` loading (e.g., via `dotenv`)
 - Add `spec/_envi.json` to `.gitignore` and provide `spec/_envi.json.example` with placeholder values
 - Validate that no real credentials are embedded in test files
+
+**Scope boundaries:**
+- Replace committed fixture secrets with documented local test configuration.
+- Do not remove deterministic test accounts until specs can create and clean up
+  their own fixtures.
+- Keep CI configuration explicit about required test-only values.
+
+**Acceptance criteria:**
+- Real-looking owner IDs, API keys, session IDs, and emails are removed from
+  committed fixture files.
+- An example fixture file documents every required key with safe placeholder
+  values.
+- CI and local test setup can load the same fixture schema without manual file
+  edits.
+- Secret scanning on the touched files reports no credentials.
+
+**Validation steps:**
+- Run `npm test`.
+- Run a secret scan or targeted `rg` check for the removed fixture values.
+- Start from a clean checkout, follow the documented fixture setup, and confirm
+  tests can begin without missing-key errors.
+
+**Risks and implementation notes:**
+- Replacing fixtures can break integration specs that assume stable IDs; migrate
+  specs in small groups and document any required seed data.
+- Avoid printing loaded fixture values in CI logs.
 
 ---
 
@@ -207,6 +417,31 @@ And `package.json`:
 
 **Benefits:** Prevents lint regressions from being committed, enforces code quality at the source.
 
+**Scope boundaries:**
+- Add hooks for lightweight checks only; long integration tests should remain in
+  CI.
+- Keep hook setup optional for contributors who have not run
+  `npm run setup:hooks`.
+- Avoid modifying package scripts unrelated to commit-time validation.
+
+**Acceptance criteria:**
+- `husky` or the existing `.githooks` workflow runs lint-staged checks before a
+  commit.
+- Only staged JavaScript files are linted and rewritten.
+- Hook documentation explains how to install, bypass intentionally, and
+  troubleshoot local failures.
+- CI continues to run the authoritative lint and test commands.
+
+**Validation steps:**
+- Run `npm install` if dependencies change.
+- Run the pre-commit hook command manually against a staged sample file.
+- Run `npm run lint` and `npm test` before merge.
+
+**Risks and implementation notes:**
+- Hook rewrites can surprise contributors; keep the staged file list narrow and
+  document the behavior.
+- Do not rely on hooks as the only quality gate because hooks can be bypassed.
+
 ---
 
 ### 14. Parallelize Jasmine Test Suite
@@ -218,6 +453,31 @@ And `package.json`:
 - Evaluate [`jasmine-parallel`](https://www.npmjs.com/package/jasmine-parallel) or switch to [Jest](https://jestjs.io/) which has native worker-based parallelism
 - Group tests by dependency (unit tests in one worker, integration tests in another) to avoid port conflicts
 - Set `"random": true` to detect hidden test-order dependencies before parallelizing
+
+**Scope boundaries:**
+- Measure current CI test duration before changing the runner.
+- Separate pure unit specs from specs that require CouchDB, Redis, MQTT, file
+  system state, or shared ports.
+- Do not change assertions while changing runner topology unless a hidden order
+  dependency is being fixed.
+
+**Acceptance criteria:**
+- Test groups are documented by dependency and concurrency safety.
+- Parallel execution reduces CI wall-clock time without increasing flakes.
+- Order-dependent specs are either fixed or pinned with a clear reason.
+- CI artifacts make failed parallel workers easy to inspect.
+
+**Validation steps:**
+- Run the current sequential suite and record baseline duration.
+- Run the proposed parallel suite repeatedly in CI or a CI-like local
+  environment.
+- Compare failure logs and coverage output against the sequential run.
+
+**Risks and implementation notes:**
+- Integration specs may mutate shared databases or queues; isolate state before
+  increasing concurrency.
+- Randomization should land before parallelization so order coupling is visible
+  while failures are still easy to reproduce.
 
 ---
 
@@ -238,12 +498,36 @@ And `package.json`:
   ```
 - Upgrade `docker-compose.yml` to Compose V2 format (remove the `version:` key)
 
+**Scope boundaries:**
+- Pin the API image base first, then repeat for worker and builder images.
+- Keep runtime package upgrades separate from digest pinning unless the digest
+  update requires a compatibility fix.
+- Validate Docker Compose and Swarm deployment paths independently.
+
+**Acceptance criteria:**
+- Every maintained runtime Dockerfile uses a versioned tag or digest with a
+  documented update process.
+- The API service has a health check that exercises `/api/v2/status`.
+- Compose V2 syntax validates without the deprecated top-level version key.
+- CI builds use the same pinned base as local builds.
+
+**Validation steps:**
+- Run `docker compose config`.
+- Build the affected image locally or in CI.
+- Start the API container and verify the health check transitions to healthy.
+
+**Risks and implementation notes:**
+- Digest pinning improves reproducibility but can freeze security updates; pair
+  it with scheduled dependency review.
+- Health checks must avoid authenticated endpoints and external dependencies
+  that make healthy containers look failed during dependency outages.
+
 ---
 
-### 16. Resolve TODO/FIXME Debt
+### 16. Resolve Source Comment Debt
 **Effort:** Medium (2–3 days)
 
-There are **17 `TODO`/`FIXME` comments** in `lib/`, several with security or correctness implications:
+There are **17 unresolved debt-marker comments** in `lib/`, several with security or correctness implications:
 
 | File | Issue |
 |---|---|
@@ -254,7 +538,33 @@ There are **17 `TODO`/`FIXME` comments** in `lib/`, several with security or cor
 | `lib/router.js:109` | `403` should be `401` for unauthenticated requests |
 | `lib/router.slack.js:27` | Slack OAuth code not validated before use |
 
-**Recommendation:** Triage each TODO into a tracked issue or fix it. At minimum, address the security-relevant items (`notifier.js` channel config, `transfer.js` promise conversion, Slack code validation) in one pass.
+**Recommendation:** Triage each source comment into a tracked issue or fix it.
+At minimum, address the security-relevant items (`notifier.js` channel config,
+`transfer.js` promise conversion, Slack code validation) in one pass.
+
+**Scope boundaries:**
+- Start with security and correctness comments in `lib/`.
+- Do not delete a source comment unless the issue is fixed, documented
+  elsewhere, or converted into a tracked backlog item.
+- Keep cosmetic comment cleanup separate from runtime fixes.
+
+**Acceptance criteria:**
+- Each security-relevant comment has either a merged fix or a linked issue with
+  owner, priority, and acceptance criteria.
+- Remaining comments describe why the work is deferred and what would close it.
+- The backlog no longer contains anonymous or unactionable debt entries.
+
+**Validation steps:**
+- Search `lib/` for deferred-work markers before and after the change and
+  review each remaining match.
+- Run focused tests for any fixed code path.
+- Run `npm test` when runtime code changes are included.
+
+**Risks and implementation notes:**
+- Removing comments without fixing the underlying issue hides known risk; prefer
+  linked issues over silent deletion.
+- Some comments may reveal security-sensitive implementation details, so public
+  issue text should be clear without exposing exploitable specifics.
 
 ---
 
@@ -277,4 +587,4 @@ There are **17 `TODO`/`FIXME` comments** in `lib/`, several with security or cor
 | 13 | Add pre-commit hooks (husky) | Low | Small | Developer Experience |
 | 14 | Parallelize Jasmine test suite | Low | Small | Developer Experience |
 | 15 | Pin/upgrade Docker base image + healthcheck | Low | Small | DevOps/Reliability |
-| 16 | Resolve TODO/FIXME debt | Low | Medium | Code Quality |
+| 16 | Resolve source comment debt | Low | Medium | Code Quality |

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -9,6 +9,10 @@ Analysis performed on the current codebase (~11K LOC across 62+ library files, 5
 
 ### 1. Replace `console.log` with a Structured Logger
 **Effort:** Medium (2–3 days)
+**Owner:** THiNX backend maintainers
+**Status:** Open
+**Next action:** Choose Pino or Winston, then migrate one backend module as the
+first reviewable slice.
 
 The codebase contains **792 `console.log` calls** across **49 files** in `lib/`. This makes it impossible to control log levels in production, route logs to aggregation services (e.g., Loki, Datadog), or filter noise from signal.
 
@@ -53,7 +57,10 @@ The codebase contains **792 `console.log` calls** across **49 files** in `lib/`.
 
 ### 2. ~~Fix Potential Command Injection in `builder.js`~~ ✅ Implemented
 **Effort:** Small (1 day)
+**Owner:** THiNX backend maintainers
 **Status:** Completed.
+**Next action:** Keep argument-array execution as the default and require
+security review for any future shell execution in build paths.
 
 The risky shell construction in [lib/thinx/builder.js](/Users/igraczech/Repositories/thinx-device-api/lib/thinx/builder.js) has been reduced substantially. Local builder execution now uses `spawn(cmd, args)` without `{ shell: true }`, Git metadata lookups use `execFileSync("git", args, { cwd })`, and public source prefetch now runs structured Git commands instead of interpolated shell strings. The remaining worker-side command string is built through `shell-escape`, and invalid sanitized Git URL or branch values now fail early instead of being passed through to shell execution.
 
@@ -65,7 +72,10 @@ The risky shell construction in [lib/thinx/builder.js](/Users/igraczech/Reposito
 
 ### 3. Update Critical Outdated Dependencies
 **Effort:** Medium (1–2 days per major update)
+**Owner:** THiNX backend maintainers
 **Status:** Completed.
+**Next action:** Continue routine dependency review and keep the documented
+`chai` version lock until the test suite is migrated.
 
 Several dependencies were significantly behind their latest versions, with potential security implications. The repo now includes the Redis 5 / `connect-redis@9` refresh, `bcrypt@^6.0.0`, `base-64@^1.0.0`, and the other safe updates in both the root manifest and the `base` image manifest. The Redis migration was validated by CircleCI pipeline `5136` on `thinx-staging`, with `test`, `build-vue-console`, `build-console-classic`, and `build-api-cloud` all passing.
 
@@ -75,6 +85,10 @@ Several dependencies were significantly behind their latest versions, with poten
 
 ### 4. Migrate from Callback-Heavy Code to Async/Await
 **Effort:** Large (1–2 weeks)
+**Owner:** THiNX backend maintainers
+**Status:** Open
+**Next action:** Convert `lib/thinx/apikey.js` first while preserving the
+current CommonJS exports and callback-compatible caller behavior.
 
 The codebase has **742 callback usages** (`callback`, `cb)`) but only ~39 `async` function declarations. The `.then()` pattern appears in 29 places, and the predominant style is nested callback chains, making error handling fragile and code hard to follow.
 
@@ -120,6 +134,10 @@ Use `util.promisify` for Node core callbacks and wrap CouchDB (`nano`) calls wit
 
 ### 5. Strengthen Error Handling
 **Effort:** Medium (2–3 days)
+**Owner:** THiNX backend maintainers
+**Status:** Open
+**Next action:** Define the shared JSON error envelope, then add Express error
+middleware and process-level rejection reporting in a focused PR.
 
 There are only **58 `try` blocks** and **81 `catch` blocks** across the entire `lib/thinx/` directory. Many async operations (CouchDB queries, Redis calls, file operations) lack proper error handling, leading to unhandled promise rejections or silent failures. Neither `thinx.js` nor `thinx-core.js` register global process-level error handlers, so unhandled rejections crash or silently disappear.
 
@@ -161,6 +179,10 @@ There are only **58 `try` blocks** and **81 `catch` blocks** across the entire `
 
 ### 6. Resolve Hardcoded RSA Key Passphrase
 **Effort:** Small (half day)
+**Owner:** THiNX security/backend maintainers
+**Status:** Open
+**Next action:** Define the runtime configuration key, production fallback
+policy, and existing-key migration or rotation plan before changing code.
 
 `lib/thinx/rsakey.js:130` contains a hardcoded passphrase `'thinx'` for RSA key encryption and an inline note that key encryption should move to secure storage:
 ```js
@@ -206,7 +228,10 @@ passphrase: 'thinx'
 
 ### 7. ~~Reduce Unrealistic 99% Test Coverage Threshold~~ ✅ Implemented
 **Effort:** Small (1 hour)
+**Owner:** THiNX backend maintainers
 **Status:** Completed.
+**Next action:** Keep the overall thresholds unless test boundaries are split
+into separate unit and integration gates.
 
 The nyc config in [`.nycrc`](/Users/igraczech/Repositories/thinx-device-api/.nycrc) previously enforced **99% for lines, statements, functions, and branches** on a per-file basis. That is effectively a regression trap for normal maintenance work, so it has been replaced with an overall threshold that is still meaningful but realistic.
 
@@ -228,6 +253,10 @@ The nyc config in [`.nycrc`](/Users/igraczech/Repositories/thinx-device-api/.nyc
 
 ### 8. Enable Stricter ESLint Rules Incrementally
 **Effort:** Small–Medium (1–2 days)
+**Owner:** THiNX backend maintainers
+**Status:** Open
+**Next action:** Enable `eqeqeq` for backend files first and submit the
+mechanical fixes separately from behavior changes.
 
 The current `.eslintrc.js` disables nearly all rules, including critical ones:
 - `"eqeqeq": 0` — allows `==` instead of `===` (type coercion bugs)
@@ -266,6 +295,11 @@ The current `.eslintrc.js` disables nearly all rules, including critical ones:
 ---
 
 ### 9. ~~Add OpenAPI/Swagger Specification~~ ✅ Implemented
+**Effort:** Completed
+**Owner:** THiNX API maintainers
+**Status:** Completed with optional follow-up
+**Next action:** Decide whether the optional Swagger UI route is worth adding
+for browser-based API exploration.
 
 **Implemented:** `thinx-api-openapi.yaml` created with 45 endpoints covering all v2 API routes (devices, auth, users, GDPR, mesh, RSA keys, logs, sources, transfer, OAuth, Slack). Served at `GET /api/v2/spec` via `lib/router.js`.
 
@@ -275,6 +309,10 @@ The current `.eslintrc.js` disables nearly all rules, including critical ones:
 
 ### 10. Per-Endpoint Rate Limiting for Auth Routes
 **Effort:** Small (half day)
+**Owner:** THiNX security/backend maintainers
+**Status:** Open
+**Next action:** Define strict limits for login, registration, password reset,
+and token exchange routes, including proxy-aware keying behavior.
 
 `thinx-core.js` applies a single global rate limiter (500 req/min) to all routes, but only in non-test environments. Sensitive authentication endpoints (`/api/login`, `/api/register`, `/api/password`) need significantly tighter limits to prevent brute-force and credential-stuffing attacks.
 
@@ -313,6 +351,10 @@ The current `.eslintrc.js` disables nearly all rules, including critical ones:
 
 ### 11. Add JSDoc Type Annotations to Public APIs
 **Effort:** Medium (3–5 days)
+**Owner:** THiNX backend maintainers
+**Status:** Open
+**Next action:** Pick the first large module and derive typedefs from existing
+specs and observed CouchDB document shapes.
 
 The codebase has **fewer than 60 JSDoc annotations** across all `lib/thinx/` files. Public-facing module methods (especially in `device.js`, `owner.js`, `builder.js`) have no type documentation.
 
@@ -355,6 +397,10 @@ The codebase has **fewer than 60 JSDoc annotations** across all `lib/thinx/` fil
 
 ### 12. Eliminate Hardcoded Test Credentials
 **Effort:** Small (half day)
+**Owner:** THiNX backend/QA maintainers
+**Status:** Open
+**Next action:** Move real-looking fixture values into documented local test
+configuration and add a safe example fixture.
 
 `spec/_envi.json` contains hardcoded owner IDs, API keys, session IDs, and email addresses. While these appear to be test fixtures, they establish a pattern that can bleed into actual credential leakage in CI logs or accidental commits.
 
@@ -393,6 +439,10 @@ The codebase has **fewer than 60 JSDoc annotations** across all `lib/thinx/` fil
 
 ### 13. Add Pre-Commit Hooks via Husky
 **Effort:** Small (2–4 hours)
+**Owner:** THiNX developer experience maintainers
+**Status:** Open
+**Next action:** Choose Husky or the repository's existing hook convention,
+then wire `lint-staged` for staged JavaScript files only.
 
 There are no pre-commit hooks configured. Developers can commit code that fails linting or tests without any friction point.
 
@@ -446,6 +496,10 @@ And `package.json`:
 
 ### 14. Parallelize Jasmine Test Suite
 **Effort:** Small–Medium (1 day)
+**Owner:** THiNX backend/QA maintainers
+**Status:** Open
+**Next action:** Capture the current CI duration baseline and classify specs by
+shared dependency before changing runner topology.
 
 `spec/support/jasmine.json` runs all 55 test files sequentially (`"random": false`, `"timeout": 10000`). With many integration-style tests that await I/O (CouchDB, Redis, MQTT), sequential execution significantly inflates total CI run time.
 
@@ -483,6 +537,10 @@ And `package.json`:
 
 ### 15. Pin and Upgrade Docker Base Image
 **Effort:** Small (2–4 hours)
+**Owner:** THiNX DevOps maintainers
+**Status:** Open
+**Next action:** Choose the base image tag or digest policy, then validate the
+API image before expanding the change to worker and builder images.
 
 `Dockerfile` uses `FROM thinxcloud/base:alpine` with no version pin. This means the build is non-reproducible and could silently pull a different base in CI or production. Additionally, `docker-compose.yml` uses Compose file format `version: '2.2'` which is deprecated.
 
@@ -526,6 +584,10 @@ And `package.json`:
 
 ### 16. Resolve Source Comment Debt
 **Effort:** Medium (2–3 days)
+**Owner:** THiNX backend/security maintainers
+**Status:** Open
+**Next action:** Triage the security-relevant source comments first and convert
+each one into either a fix PR or a tracked issue with acceptance criteria.
 
 There are **17 unresolved debt-marker comments** in `lib/`, several with security or correctness implications:
 
@@ -570,21 +632,21 @@ At minimum, address the security-relevant items (`notifier.js` channel config,
 
 ## Summary Table
 
-| # | Improvement | Priority | Effort | Impact |
-|---|---|---|---|---|
-| 1 | Structured logging (replace console.log) | High | Medium | Observability |
-| 2 | ~~Fix command injection in builder.js~~ ✅ | ~~High~~ | ~~Small~~ | Done |
-| 3 | ~~Update outdated dependencies~~ ✅ | ~~High~~ | ~~Medium~~ | Done |
-| 4 | Migrate callbacks to async/await | High | Large | Maintainability |
-| 5 | Strengthen error handling + process handlers | High | Medium | Reliability |
-| 6 | Resolve hardcoded RSA key passphrase | High | Small | Security |
-| 7 | ~~Reduce 99% coverage threshold~~ ✅ | ~~Medium~~ | ~~Small~~ | Done |
-| 8 | Enable stricter ESLint rules | Medium | Medium | Code Quality |
-| 9 | ~~Add OpenAPI/Swagger specification~~ ✅ | ~~Medium~~ | ~~Medium~~ | Done |
-| 10 | Per-endpoint rate limiting for auth routes | Medium | Small | Security |
-| 11 | Add JSDoc type annotations | Medium | Medium | Maintainability |
-| 12 | Eliminate hardcoded test credentials | Low | Small | Security hygiene |
-| 13 | Add pre-commit hooks (husky) | Low | Small | Developer Experience |
-| 14 | Parallelize Jasmine test suite | Low | Small | Developer Experience |
-| 15 | Pin/upgrade Docker base image + healthcheck | Low | Small | DevOps/Reliability |
-| 16 | Resolve source comment debt | Low | Medium | Code Quality |
+| # | Improvement | Priority | Owner | Status | Next action |
+|---|---|---|---|---|---|
+| 1 | Structured logging | High | THiNX backend | Open | Choose logger and migrate one backend module first. |
+| 2 | ~~Fix command injection in builder.js~~ ✅ | ~~High~~ | THiNX backend | Completed | Keep shell execution under security review. |
+| 3 | ~~Update outdated dependencies~~ ✅ | ~~High~~ | THiNX backend | Completed | Continue routine dependency review and keep the `chai` lock. |
+| 4 | Migrate callbacks to async/await | High | THiNX backend | Open | Convert `lib/thinx/apikey.js` first with compatible callers. |
+| 5 | Strengthen error handling + process handlers | High | THiNX backend | Open | Define JSON error envelope and central middleware. |
+| 6 | Resolve hardcoded RSA key passphrase | High | THiNX security/backend | Open | Define config, fallback policy, and key migration plan. |
+| 7 | ~~Reduce 99% coverage threshold~~ ✅ | ~~Medium~~ | THiNX backend | Completed | Keep thresholds unless test gates are split. |
+| 8 | Enable stricter ESLint rules | Medium | THiNX backend | Open | Enable `eqeqeq` for backend files first. |
+| 9 | ~~Add OpenAPI/Swagger specification~~ ✅ | ~~Medium~~ | THiNX API | Completed with optional follow-up | Decide on Swagger UI route. |
+| 10 | Per-endpoint rate limiting for auth routes | Medium | THiNX security/backend | Open | Define route limits and proxy-aware keys. |
+| 11 | Add JSDoc type annotations | Medium | THiNX backend | Open | Pick first large module and derive typedefs from specs. |
+| 12 | Eliminate hardcoded test credentials | Low | THiNX backend/QA | Open | Move fixture values to documented local test configuration. |
+| 13 | Add pre-commit hooks | Low | THiNX developer experience | Open | Choose hook convention and wire staged JS linting. |
+| 14 | Parallelize Jasmine test suite | Low | THiNX backend/QA | Open | Capture CI baseline and classify specs by dependency. |
+| 15 | Pin/upgrade Docker base image + healthcheck | Low | THiNX DevOps | Open | Choose base image tag or digest policy. |
+| 16 | Resolve source comment debt | Low | THiNX backend/security | Open | Triage security-relevant comments into fixes or tracked issues. |

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -4,6 +4,14 @@
 
 Describe the problem or task in one or two sentences.
 
+## Task Metadata
+
+- Owner:
+- Status:
+- Next action:
+- Priority:
+- Target branch or environment:
+
 ## Context
 
 - Affected service, module, route, or document:
@@ -18,16 +26,18 @@ Describe the desired end state from the user's or operator's point of view.
 ## Scope
 
 In scope:
-- Add specific included work here.
+- Included work:
 
 Out of scope:
-- Add known exclusions here.
+- Excluded work:
 
 ## Acceptance Criteria
 
-- [ ] The requested behavior or documentation change is implemented.
+- [ ] Owner, status, and next action are set before implementation starts.
+- [ ] Expected outcome is met for the affected service, module, route, or document.
+- [ ] Scope exclusions are documented so deferred work is visible.
 - [ ] Edge cases and failure modes are covered or explicitly deferred.
-- [ ] Security, privacy, and operational impacts have been reviewed.
+- [ ] Security, privacy, and operational impacts are reviewed.
 - [ ] User-facing or operator-facing documentation is updated when needed.
 
 ## Validation
@@ -35,10 +45,10 @@ Out of scope:
 - Command or manual check:
 - Expected result:
 - Environment used:
+- Evidence link, log excerpt, or screenshot:
 
 ## Deployment Notes
 
-- Target branch or environment:
 - Required configuration or secret changes:
 - Rollback plan:
 - Monitoring or smoke checks after deployment:

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,1 +1,44 @@
-Nothing so far. Report your issues ad libitum. User errors are accepted so far, however those will be redirected to Knowledge Base later.
+# Issue Template
+
+## Summary
+
+Describe the problem or task in one or two sentences.
+
+## Context
+
+- Affected service, module, route, or document:
+- Current behavior or gap:
+- Why this matters:
+- Related logs, screenshots, links, or prior work:
+
+## Expected Outcome
+
+Describe the desired end state from the user's or operator's point of view.
+
+## Scope
+
+In scope:
+- Add specific included work here.
+
+Out of scope:
+- Add known exclusions here.
+
+## Acceptance Criteria
+
+- [ ] The requested behavior or documentation change is implemented.
+- [ ] Edge cases and failure modes are covered or explicitly deferred.
+- [ ] Security, privacy, and operational impacts have been reviewed.
+- [ ] User-facing or operator-facing documentation is updated when needed.
+
+## Validation
+
+- Command or manual check:
+- Expected result:
+- Environment used:
+
+## Deployment Notes
+
+- Target branch or environment:
+- Required configuration or secret changes:
+- Rollback plan:
+- Monitoring or smoke checks after deployment:

--- a/docs/THiNX Migration Tasklist.md
+++ b/docs/THiNX Migration Tasklist.md
@@ -1,41 +1,51 @@
-# THiNX Migration Issues
+# THiNX Migration Tasklist
+
+This document tracks migration and container-hardening work for the THiNX
+deployment stack. Each row should be actionable without needing to infer the
+next owner decision from older notes.
 
 ## Container Security Review
 
-| Container    | State     | Owner | Security
-|:-------------|:----------|:------|:----------
-| api          | published | THiNX | Tested 719 dependencies for known issues, found 3 issues.
-| alpine-gulp  | published | THiNX | OK
-| base         | published | THiNX | Tested 192 dependencies for known issues, found 165 issues.
-| broker       | published | OSS   | Tested 100 dependencies for known issues, found 73 issues in vendor base image.
-| console      | custom-built | User | needs custom build, prefixed using `thinx/` which is private namespace
-| couchdb      | published | OSS   | Tested 134 dependencies for known issues, found 92 issues in vendor base image. 
-| redis        | published | OSS   | Tested 92 dependencies for known issues, found 69 issues in vendor base image.
-| transformer  | published | THiNX | OK
-| worker       | published | THiNX | OK
-| TODO: builders | published | THiNX | Unknown
+| Container | State | Owner | Status | Next action | Acceptance criteria |
+|:----------|:------|:------|:-------|:------------|:--------------------|
+| `api` | Published | THiNX | Needs vulnerability follow-up | Review the 3 reported dependency issues and decide whether each is patched, accepted, or blocked by a base image update. | Scan result is linked, each issue has a disposition, and the API image rebuilds from the documented base image. |
+| `alpine-gulp` | Published | THiNX | Accepted | Keep current image published and include it in scheduled image scans. | Latest scan remains clean or new findings are tracked in the backlog. |
+| `base` | Published | THiNX | High-risk dependency backlog | Identify the packages behind the 165 reported issues and decide whether to rebuild the base image or replace it. | A new base image digest or accepted-risk record is documented before downstream images are rebuilt. |
+| `broker` | Published | OSS | Vendor image risk | Track vendor base image updates and confirm whether THiNX can override the base safely. | Broker deployment references a patched vendor image, a THiNX-maintained derivative, or a documented risk acceptance. |
+| `console` | Custom-built | User | Namespace and publication decision needed | Decide whether the console should remain private under `thinx/` or move to a documented THiNX image namespace. | Build source, image name, registry namespace, and deployment reference are documented and reproducible. |
+| `couchdb` | Published | OSS | Vendor image risk | Track vendor updates for the 92 reported issues and confirm compatibility with the current CouchDB data volume. | Target image version is documented with migration and rollback notes. |
+| `redis` | Published | OSS | Vendor image risk | Track vendor updates for the 69 reported issues and confirm session compatibility with Redis 5 client behavior. | Target image version is documented, staging starts cleanly, and session storage smoke tests pass. |
+| `transformer` | Published | THiNX | Accepted | Keep image in scheduled scans and rebuild when the base image changes. | Latest scan remains clean or new findings are tracked in the backlog. |
+| `worker` | Published | THiNX | Accepted with builder dependency | Keep worker image in scheduled scans and validate any builder contract changes against it. | Worker can dispatch builds to every supported builder image in staging. |
+| `builders` | Published | THiNX | Inventory incomplete | List each one-shot builder image, Dockerfile path, base image, command contract, and security scan result. | Builder inventory is complete and every supported firmware target has a documented image owner and rebuild path. |
 
+## Migration Tasks
 
+| ID | Task | Owner | Status | Next action | Acceptance criteria |
+|:---|:-----|:------|:-------|:------------|:--------------------|
+| MIG-001 | Builder image inventory | THiNX | Open | Map all one-shot builder containers used by the worker, including Arduino and PlatformIO variants. | The inventory includes image name, registry, Dockerfile path, base image, supported target, command entrypoint, scan status, and current deployment consumer. |
+| MIG-002 | Builder image hardening plan | THiNX | Open | For each builder image, decide whether to pin the base image, rebuild from a patched base, or retire the image. | Every builder image has an owner decision, target base digest or tag, and validation command. |
+| MIG-003 | Console image publication decision | THiNX/User | Open | Decide whether the custom console image remains user-built or becomes a published THiNX image. | Deployment docs name the registry namespace, tag policy, build command, and rollback image for the console. |
+| MIG-004 | Base image refresh | THiNX | Open | Review whether `thinxcloud/base:alpine` should be rebuilt, pinned, or replaced. | Downstream API, worker, transformer, and builder rebuild plans reference the selected base image digest or tag. |
+| MIG-005 | Compose and Swarm deployment parity | THiNX | Open | Validate that Docker Compose and Docker Swarm use the same image names, environment variables, and health checks where applicable. | A staging deployment can be recreated from documented Compose or Swarm files without manual image substitutions. |
+| MIG-006 | Vendor image update review | THiNX | Open | Review broker, CouchDB, and Redis vendor image upgrades against data compatibility and runtime configuration. | Each vendor image has an upgrade target, compatibility note, and rollback instruction. |
 
-## THiNX Architecture - Main Components
+## Architecture Components
 
-THiNX can be deployed using bare Docker containers (well, we have not tried that for a while), using Docker Compose or Docker Swarm with extended deployment tags for Swarmpit.
+THiNX can be deployed with Docker Compose or Docker Swarm using extended
+deployment tags for Swarmpit. Bare Docker container deployment has not been
+validated recently. Kubernetes and other orchestrators are outside the current
+migration scope until a deployment owner requests and defines that work.
 
-K8s or other container orchestrator compatibility is not yet supported. Fell free to request it.
-
-| Service Name | Purpose   
-|:-------------|:-----------
-| Traefik      | Ingress Router and SSL manager
-| Swarmpit     | Container Orcherstrator / Monitoring
-| |
-| API          | REST API
-| Console      | Single-page UI App
-| |
-| Broker       | Message Queue
-| Transformer  | Lambda Execution Sandbox
-| Worker       | Build Dispatcher
-| |
-| Redis        | High-speed User Data and Session Storage
-| CouchDB      | Medium-speed User Data Storage
-| |
-| Builders     | TODO: 5+ different one-shot containers (hardcoded for security)
+| Service name | Purpose | Migration note |
+|:-------------|:--------|:---------------|
+| Traefik | Ingress router and SSL manager | Keep routing and TLS behavior aligned between Compose and Swarm. |
+| Swarmpit | Container orchestrator and monitoring UI | Used for task rollout monitoring in the current deployment flow. |
+| API | REST API | Rebuild after base image and dependency changes. |
+| Console | Single-page UI app | Clarify image namespace and publication ownership. |
+| Broker | Message queue | Track vendor image security updates. |
+| Transformer | Lambda execution sandbox | Rebuild when the base image changes. |
+| Worker | Build dispatcher | Validate builder image contracts after any builder migration. |
+| Redis | High-speed user data and session storage | Validate sessions after image or client upgrades. |
+| CouchDB | Medium-speed user data storage | Validate data volume compatibility before image upgrades. |
+| Builders | One-shot firmware build containers | Inventory and harden each supported builder image. |


### PR DESCRIPTION
## Summary
- add owner, status, and next-action metadata to every `IMPROVEMENTS.md` backlog item
- replace the backlog summary table with a scan-friendly owner/status/next-action table
- keep the migration tasklist as explicit owner/status/next-action/acceptance-criteria work items
- expand `ISSUE_TEMPLATE.md` so new issues capture task metadata, scope, acceptance criteria, validation evidence, and deployment notes

## Validation
- `git diff --check`
- `rg -n "\\b(TODO|FIXME|TBD)\\b|ad libitum" IMPROVEMENTS.md ISSUE_TEMPLATE.md docs/THiNX\\ Migration\\ Tasklist.md` returned no matches
- `rg -n "^\\*\\*(Owner|Status|Next action):" IMPROVEMENTS.md` confirmed owner/status/next-action metadata for all 16 backlog items
- reviewed the changed Markdown sections for table and heading structure
- `npm test` was attempted, but the script masks Jasmine startup errors; without environment config it reports missing `/mnt/data/conf/config.json`
- `ENVIRONMENT=development npm test` loads the bundled development config but is blocked by missing `MAILGUN_API_KEY`
- `ENVIRONMENT=development MAILGUN_API_KEY=test npm test` proceeds further and is blocked by missing CouchDB endpoint configuration/services

Nightshift-Task: task-groomer
Nightshift-Ref: https://github.com/marcus/nightshift