### PR TITLE
docs: draft release notes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,14 @@
 
 ## HISTORY
 
+6/7/2026 1.13 — Web Hardening
+
+» Browser session cookies now set SameSite=Lax, and double-submit CSRF protection is available behind `debug.csrf_enforce` / `CSRF_ENFORCE` using `XSRF-TOKEN` plus `X-XSRF-TOKEN`.
+» Login, password reset, user-create, and password-set POST routes now mint and validate CSRF tokens with `/api/csrf-token` and `/api/v2/csrf-token` priming endpoints; CORS allows the token header for the Vue console.
+» Classic and Vue console login, OAuth, and password flows now prime and send CSRF tokens; console CSP templates pin known THiNX, Crisp, Google, and Rollbar hosts instead of broad `https:` / `wss:` scheme wildcards.
+» Worker and Arduino builder submodules moved to security and operational fixes: worker command-injection, job-auth, and Docker-secret hardening; Arduino builder Debian 13.5 base, cflags handling, and deploy status markers.
+» MQTT-heavy CI specs are more stable via a larger API libuv DNS thread pool and MQTT reconnect timeouts, without the deadlocking mosquitto healthcheck.
+
 29/6/2026 1.12 — Inbox Drawdown
 
 » Device-transfer e-mails now render as HTML instead of raw markup (#541)


### PR DESCRIPTION
## Summary
- Add a new top `HISTORY.md` entry for `6/7/2026 1.13 — Web Hardening`.
- Summarize changes since the `29/6/2026 1.12` entry: CSRF/SameSite hardening, console CSP/CSRF wiring, worker and Arduino builder operational fixes, and MQTT-heavy CI stability.
- Update the `services/console` submodule pointer to include the console changelog-only release-note commit from thinx-cloud/console#27.

## Files changed
- `HISTORY.md`
- `services/console` submodule pointer (`d41d4ba8` -> `1dac7023`)
- Console submodule PR: https://github.com/thinx-cloud/console/pull/27

## Verification
- `git diff --check -- HISTORY.md`
- `git -C services/console diff --check -- CHANGELOG.md`
- Manual markdown diff review with `git diff -- HISTORY.md` and `git -C services/console diff -- CHANGELOG.md`

## Assumptions
- The release-note scope starts after the documented `29/6/2026 1.12` root history entry.
- Submodule pointer changes are included only where they represent release-facing security or operational behavior.
- Pre-existing dirty state was preserved and not staged: `services/broker`, submodule untracked files, and root `nightshift.yaml`.
